### PR TITLE
feat: add waterfall enrichments with real-time field updates

### DIFF
--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -150,6 +150,8 @@ export interface ExtractionJob {
   // Multi-document support: keyed by input field ID
   // For backward compatibility: if undefined, treat originalFileUrl as implicit default input
   inputDocuments?: Record<string, InputDocument>
+  // Waterfall enrichments: tracks fields currently being enriched/transformed
+  enrichingFields?: string[] // Array of field IDs currently being processed
 }
 
 export interface VisualGroup {


### PR DESCRIPTION
After file upload, extraction results now display progressively:
- Base extraction results show immediately before transformations start
- Each transformation wave updates the UI as it completes
- Fields being enriched show a loading indicator with "enriching..." text
- Results appear in real-time rather than waiting for all processing

Changes:
- Add enrichingFields to ExtractionJob to track field-level loading state
- Update job results incrementally after base extraction and each wave
- Add visual indicator for fields currently being enriched