### PR TITLE
Fix text-input panels showing fake .txt filename + tint input panels

### DIFF
--- a/components/mission-control/DocumentMissionControl.tsx
+++ b/components/mission-control/DocumentMissionControl.tsx
@@ -263,9 +263,17 @@ export function DocumentMissionControl({ job, schema, onUpdateResults }: Documen
         switch (panel.type) {
             case 'input-document':
                 const doc = panel.inputDocument || panel.value
+                // Text inputs come in wrapped as a virtual ${field}.txt File with a blob URL
+                // (DataExtractionPlatform line ~2410). If we hand that URL to MCSourcePanel
+                // it tries to <img src> the .txt and falls back to the alt text. Detect text
+                // inputs and route through MCSourcePanel's text branch by suppressing imageUrl.
+                const isTextInput =
+                    panel.inputField?.inputType === 'text' ||
+                    doc?.inputType === 'text' ||
+                    (typeof doc?.textValue === 'string' && doc.textValue.trim().length > 0 && !doc?.previewUrl)
                 return (
                     <MCSourcePanel
-                        imageUrl={doc?.previewUrl || doc?.fileUrl}
+                        imageUrl={isTextInput ? null : (doc?.previewUrl || doc?.fileUrl)}
                         fileName={doc?.fileName || panel.label}
                         textContent={doc?.textValue}
                     />

--- a/components/mission-control/panels/MCPanel.tsx
+++ b/components/mission-control/panels/MCPanel.tsx
@@ -75,6 +75,8 @@ export function MCPanel({
     // Default min sizes based on type
     const minHeight = type === 'table' ? 200 : (type === 'source' || type === 'input-document') ? 200 : 100
 
+    const isInputPanel = type === 'input-document'
+
     return (
         <div
             ref={setNodeRef}
@@ -84,9 +86,14 @@ export function MCPanel({
             }}
             {...attributes}
             className={cn(
-                "group bg-white border border-slate-200 rounded-lg overflow-hidden",
+                "group rounded-lg overflow-hidden",
                 "hover:shadow-md transition-shadow",
                 "resize overflow-auto", // CSS resize capability
+                // Input-document panels get an amber tint so the user can tell at a glance
+                // which cards are inputs they provided vs. generated/transformation outputs.
+                isInputPanel
+                    ? "bg-amber-50/40 border border-amber-200"
+                    : "bg-white border border-slate-200",
                 isDragging && "opacity-50 shadow-lg ring-2 ring-primary/50 z-50",
                 // Size classes for grid spanning
                 size === 'large' && "col-span-1 md:col-span-2",
@@ -97,7 +104,12 @@ export function MCPanel({
             {/* Panel Header - Draggable */}
             <div
                 {...listeners}
-                className="flex items-center gap-2 px-3 py-2 border-b border-slate-100 bg-slate-50/50 cursor-grab active:cursor-grabbing"
+                className={cn(
+                    "flex items-center gap-2 px-3 py-2 border-b cursor-grab active:cursor-grabbing",
+                    isInputPanel
+                        ? "bg-amber-100/60 border-amber-200"
+                        : "bg-slate-50/50 border-slate-100",
+                )}
             >
                 {titleIcon || <Icon className={cn("h-4 w-4 shrink-0", config.color)} />}
                 <span className="text-sm font-medium text-slate-700 truncate flex-1">


### PR DESCRIPTION
## Summary
Two fixes to the Mission Control document viewer surfaced while running the **Drug Trade Name Proposer (SFDA)** schema (which has many text-input fields).

## Bug 1 — Text inputs rendered as fake .txt files
Text inputs are wrapped client-side into a virtual \`\${field}.txt\` File with a blob URL ([components/DataExtractionPlatform.tsx:2410](components/DataExtractionPlatform.tsx:2410)). \`MCSourcePanel\` was receiving that blob URL as \`imageUrl\` and trying to \`<img src>\` the .txt — the user saw the \`alt\` text fallback (e.g. \`scientific_name.txt\`) instead of the typed content.

**Fix**: in \`DocumentMissionControl.renderPanelContent\`, detect text inputs (\`inputType === 'text'\` or a non-empty \`textValue\` with no \`previewUrl\`) and pass \`imageUrl={null}\` so MCSourcePanel falls into its existing read-only text branch.

## Bug 2 — No visual differentiation between input panels and generated panels
Every panel rendered with the same white background. User couldn't tell at a glance which cards were inputs they provided vs. generated/transformation outputs.

**Fix**: in \`MCPanel\`, give \`input-document\` panels an amber-50 background + amber-200 border, and an amber-100 header strip. Generated/transformation panels stay white.

## Files changed
- \`components/mission-control/DocumentMissionControl.tsx\` — text-input detection + imageUrl suppression
- \`components/mission-control/panels/MCPanel.tsx\` — amber tint for input-document panels

## Test plan
- [ ] Run **Drug Trade Name Proposer (SFDA)** with text inputs filled in (scientific_name, strength, etc.) → confirm cards now show the actual typed text, not \`scientific_name.txt\` etc.
- [ ] Confirm input cards now have a visible amber tint and the generated cards (\`market_landscape\`, \`proposed_name_options\`, \`recommendation\`) stay white.
- [ ] Run a schema with file uploads (e.g. **Leaflet Review**) → confirm file inputs still render the file preview / image as before (regression check).
- [ ] Verify text content is read-only — no editable affordance on input cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)