### PR TITLE
Sort extraction jobs newest-first

### DIFF
--- a/components/DataExtractionPlatform.tsx
+++ b/components/DataExtractionPlatform.tsx
@@ -1026,7 +1026,7 @@ export function DataExtractionPlatform({
   }, [activeSchema.name, isTemplateDialogOpen])
   const completedJobsCount = jobs.filter((j) => j.status === 'completed').length
   const sortedJobs = useMemo(
-    () => [...jobs].sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime()),
+    () => [...jobs].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime()),
     [jobs],
   )
 

--- a/components/features/extraction/components/FnBResultsView.tsx
+++ b/components/features/extraction/components/FnBResultsView.tsx
@@ -149,11 +149,11 @@ export function FnBResultsView({
   onToggleEnglish,
   onToggleArabic,
 }: FnBResultsViewProps) {
-  // Sort jobs by creation date
+  // Sort jobs by creation date (newest first)
   const sortedJobs = [...jobs].sort((a, b) => {
     const aTime = a.createdAt?.getTime() ?? 0
     const bTime = b.createdAt?.getTime() ?? 0
-    return aTime - bTime
+    return bTime - aTime
   })
 
   return (

--- a/components/features/extraction/components/PharmaResultsView.tsx
+++ b/components/features/extraction/components/PharmaResultsView.tsx
@@ -113,11 +113,11 @@ export function PharmaResultsView({
   onSetEditingSection,
   onSetEditedValues,
 }: PharmaResultsViewProps) {
-  // Sort jobs by creation date
+  // Sort jobs by creation date (newest first)
   const sortedJobs = [...jobs].sort((a, b) => {
     const aTime = a.createdAt?.getTime() ?? 0
     const bTime = b.createdAt?.getTime() ?? 0
-    return aTime - bTime
+    return bTime - aTime
   })
 
   return (

--- a/components/features/extraction/components/StandardResultsView.tsx
+++ b/components/features/extraction/components/StandardResultsView.tsx
@@ -187,7 +187,7 @@ export function StandardResultsView({
     const sorted = [...jobs].sort((a, b) => {
       const aTime = a.createdAt?.getTime() ?? 0
       const bTime = b.createdAt?.getTime() ?? 0
-      return aTime - bTime
+      return bTime - aTime
     });
     
     prevSortedJobsRef.current = sorted;


### PR DESCRIPTION
## Summary
- Flips the per-schema jobs list from oldest-first to **newest-first** across all four render sites: `DataExtractionPlatform` main memo, `StandardResultsView`, `PharmaResultsView`, `FnBResultsView`.
- One-token operand swap in each spot (`aTime - bTime` → `bTime - aTime`); no shape or behavior change beyond order.
- Other `created_at` orderings in the codebase already sort newest-first or apply to non-job entities (schemas, chat messages, parsers, integrations) and were intentionally left alone.

## Test plan
- [ ] Open a schema with several extraction jobs — confirm the most recent one renders at the top of the list.
- [ ] Spot-check Standard, Pharma (SFDA), and FnB (food label) result views — newest job should be first in each.
- [ ] Trigger a new extraction; verify it appears at the top of the list immediately, not the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)