### PR TITLE
Block RecipeBuilder access for trial-expired users

### DIFF
--- a/app/api/recipe-builder/access/route.ts
+++ b/app/api/recipe-builder/access/route.ts
@@ -29,20 +29,31 @@ export async function GET(request: NextRequest) {
       .from('recipe_builder_users')
       .select('email, role, is_active')
       .eq('email', user.email)
-      .eq('is_active', true)
       .single()
 
     if (error || !rbUser) {
       return NextResponse.json({
         hasAccess: false,
+        blocked: false,
         role: null,
         email: user.email,
         debug: { dbError: error?.message, code: error?.code, step: 'db_query' }
       })
     }
 
+    if (!rbUser.is_active) {
+      return NextResponse.json({
+        hasAccess: false,
+        blocked: true,
+        role: null,
+        email: user.email,
+        redirectUrl: 'https://app.recipebuilder.co',
+      })
+    }
+
     return NextResponse.json({
       hasAccess: true,
+      blocked: false,
       role: rbUser.role,
       email: user.email,
     })

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,8 +19,9 @@ import {
   RecipesView as RecipeBuilderRecipes,
   IngredientsView as RecipeBuilderIngredients,
 } from '@/components/recipe-builder'
+import { RecipeBuilderBlockedScreen } from '@/components/RecipeBuilderBlockedScreen'
 
-// Helper to check if a view is a Recipe Builder view
+// Helper to check if a view is a Recipe Builder view (includes blocked sentinel)
 function isRecipeBuilderView(view: string): boolean {
   return view.startsWith('recipe-builder')
 }
@@ -41,11 +42,15 @@ function getRecipeBuilderView(view: string) {
 
 export default function Home() {
   const [activeView, setActiveView] = React.useState("home")
+  const [isBlocked, setIsBlocked] = React.useState(false)
 
   // Render the active view content
   const renderContent = () => {
     // Recipe Builder views
     if (isRecipeBuilderView(activeView)) {
+      if (isBlocked) {
+        return <RecipeBuilderBlockedScreen />
+      }
       return (
         <RecipeBuilderProvider>
           {getRecipeBuilderView(activeView)}
@@ -73,7 +78,7 @@ export default function Home() {
   return (
     <WorkspaceProvider>
       <SidebarProvider>
-        <AppSidebar onNavigate={setActiveView} activeView={activeView} />
+        <AppSidebar onNavigate={setActiveView} activeView={activeView} onAccessResolved={setIsBlocked} />
         <SidebarInset>
           <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 border-b px-4 bg-background">
             <div className="flex items-center gap-2 px-4">

--- a/components/AppSidebar.tsx
+++ b/components/AppSidebar.tsx
@@ -69,11 +69,13 @@ function hasChildren(item: NavigationItem): item is NavItemWithChildren {
 interface AppSidebarProps {
     onNavigate: (view: string) => void
     activeView: string
+    onAccessResolved?: (blocked: boolean) => void
 }
 
-export function AppSidebar({ onNavigate, activeView }: AppSidebarProps) {
+export function AppSidebar({ onNavigate, activeView, onAccessResolved }: AppSidebarProps) {
     const [openMenus, setOpenMenus] = useState<string[]>(['recipe-builder'])
     const [hasRecipeBuilderAccess, setHasRecipeBuilderAccess] = useState(false)
+    const [isBlocked, setIsBlocked] = useState(false)
     const [accessLoading, setAccessLoading] = useState(true)
 
     // Function to check recipe builder access
@@ -82,14 +84,18 @@ export function AppSidebar({ onNavigate, activeView }: AppSidebarProps) {
             setAccessLoading(true)
             const response = await fetch('/api/recipe-builder/access')
             const data = await response.json()
+            const blocked = data.blocked === true
             setHasRecipeBuilderAccess(data.hasAccess === true)
+            setIsBlocked(blocked)
+            onAccessResolved?.(blocked)
         } catch (error) {
             console.error('Failed to check recipe builder access:', error)
             setHasRecipeBuilderAccess(false)
+            setIsBlocked(false)
         } finally {
             setAccessLoading(false)
         }
-    }, [])
+    }, [onAccessResolved])
 
     // Check access on mount and when auth state changes
     useEffect(() => {
@@ -162,6 +168,14 @@ export function AppSidebar({ onNavigate, activeView }: AppSidebarProps) {
         },
     ]
 
+    const handleNavigate = (value: string) => {
+        if (isBlocked && value.startsWith('recipe-builder')) {
+            onNavigate('recipe-builder-blocked')
+        } else {
+            onNavigate(value)
+        }
+    }
+
     const toggleMenu = (menuValue: string) => {
         setOpenMenus((prev) =>
             prev.includes(menuValue)
@@ -186,8 +200,8 @@ export function AppSidebar({ onNavigate, activeView }: AppSidebarProps) {
             return null
         }
 
-        // Check access requirements
-        if (item.requiresAccess === 'recipe-builder' && !hasRecipeBuilderAccess) {
+        // Check access requirements — show menu for blocked users so they can reach the block screen
+        if (item.requiresAccess === 'recipe-builder' && !hasRecipeBuilderAccess && !isBlocked) {
             return null
         }
 
@@ -224,7 +238,7 @@ export function AppSidebar({ onNavigate, activeView }: AppSidebarProps) {
                                             <>
                                                 <SidebarMenuSubItem>
                                                     <SidebarMenuSubButton
-                                                        onClick={() => onNavigate(child.value)}
+                                                        onClick={() => handleNavigate(child.value)}
                                                         isActive={activeView === child.value}
                                                         className="font-medium"
                                                     >
@@ -235,7 +249,7 @@ export function AppSidebar({ onNavigate, activeView }: AppSidebarProps) {
                                                 {child.children.filter(sc => !sc.hidden).map((subChild) => (
                                                     <SidebarMenuSubItem key={subChild.value}>
                                                         <SidebarMenuSubButton
-                                                            onClick={() => onNavigate(subChild.value)}
+                                                            onClick={() => handleNavigate(subChild.value)}
                                                             isActive={activeView === subChild.value}
                                                             className="pl-6"
                                                         >
@@ -247,7 +261,7 @@ export function AppSidebar({ onNavigate, activeView }: AppSidebarProps) {
                                         ) : (
                                             <SidebarMenuSubItem>
                                                 <SidebarMenuSubButton
-                                                    onClick={() => onNavigate(child.value)}
+                                                    onClick={() => handleNavigate(child.value)}
                                                     isActive={activeView === child.value}
                                                 >
                                                     {child.icon && <child.icon className="size-4" />}
@@ -267,7 +281,7 @@ export function AppSidebar({ onNavigate, activeView }: AppSidebarProps) {
         return (
             <SidebarMenuItem key={item.value}>
                 <SidebarMenuButton
-                    onClick={() => onNavigate(item.value)}
+                    onClick={() => handleNavigate(item.value)}
                     isActive={activeView === item.value}
                     tooltip={item.title}
                 >

--- a/components/RecipeBuilderBlockedScreen.tsx
+++ b/components/RecipeBuilderBlockedScreen.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { ChefHat, ExternalLink } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+export function RecipeBuilderBlockedScreen() {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center min-h-full px-4 py-16 text-center">
+      <div className="max-w-md space-y-6">
+        <div className="flex justify-center">
+          <div className="rounded-full bg-muted p-4">
+            <ChefHat className="h-10 w-10 text-muted-foreground" />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="text-2xl font-bold tracking-tight">Your RecipeBuilder trial has ended</h2>
+          <p className="text-muted-foreground">
+            To continue building and managing recipes, subscribe to RecipeBuilder through the production app.
+          </p>
+        </div>
+
+        <Button asChild size="lg" className="gap-2">
+          <a href="https://app.recipebuilder.co" target="_blank" rel="noopener noreferrer">
+            Open RecipeBuilder
+            <ExternalLink className="h-4 w-4" />
+          </a>
+        </Button>
+
+        <p className="text-xs text-muted-foreground">
+          Your recipes and data are safe. Sign in at{' '}
+          <a
+            href="https://app.recipebuilder.co"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-foreground transition-colors"
+          >
+            app.recipebuilder.co
+          </a>{' '}
+          to continue.
+        </p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Access API (`/api/recipe-builder/access`) returns `blocked: true` when user has `is_active=false` in `recipe_builder_users` table
- `AppSidebar` keeps Recipe Builder menu visible for blocked users so they can reach the block screen; all RB clicks route to `recipe-builder-blocked`
- `app/page.tsx` renders `RecipeBuilderBlockedScreen` when blocked + a RB view is active
- New `RecipeBuilderBlockedScreen`: centered full-page screen with "Your RecipeBuilder trial has ended" and a CTA to `https://app.recipebuilder.co`

## Test plan
- [ ] Log in as `meerim@bensfarmhouse.com` — Recipe Builder menu appears in sidebar
- [ ] Click any Recipe Builder sub-item → block screen appears ("Your RecipeBuilder trial has ended")
- [ ] "Open RecipeBuilder" button opens `https://app.recipebuilder.co` in a new tab
- [ ] Non-RB views (Home, Co-pilot, etc.) are unaffected
- [ ] Other users with `is_active=true` see RecipeBuilder normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)